### PR TITLE
:sparkles: feat: 열린 우편 봉투 프레임 내 이미지 불러오기 구현

### DIFF
--- a/src/components/letterbox/Envelope/Envelope.tsx
+++ b/src/components/letterbox/Envelope/Envelope.tsx
@@ -10,13 +10,14 @@ interface EnvelopeProps {
   recipient: string;
   date: string;
   sealColor?: string;
-  caption: string; 
+  caption: string;
   onClick: (id: number) => void;
   onSave: (id: number) => void;
   isSaved: boolean;
   isRead: boolean;
   activeTab: string;
   nickname: string;
+  image?: string; 
 }
 
 const Envelope = ({
@@ -26,13 +27,14 @@ const Envelope = ({
   recipient,
   date,
   sealColor,
-  caption, 
+  caption,
   onClick,
   onSave,
   isSaved,
   isRead,
   activeTab,
   nickname,
+  image, 
 }: EnvelopeProps) => {
   const handleEnvelopeClick = () => {
     onClick(id);
@@ -44,9 +46,9 @@ const Envelope = ({
   };
 
   const displayText =
-    (activeTab === "received" && sender !== recipient)
+    activeTab === "received" && sender !== recipient
       ? `From. ${sender}`
-      : (activeTab === "sent" && sender !== recipient)
+      : activeTab === "sent" && sender !== recipient
       ? `Dear. ${recipient}`
       : sender === nickname && recipient === nickname
       ? ""
@@ -60,19 +62,10 @@ const Envelope = ({
         isRead={isRead}
         sealColor={sealColor}
         onClick={handleEnvelopeClick}
-  
-        
+        image={image} 
       />
-      <SaveIconButton
-        isSaved={isSaved}
-        isRead={isRead}
-        onClick={handleSaveClick}
-      />
-      <EnvelopeText
-        displayText={displayText}
-        title={title}
-        date={date}
-      />
+      <SaveIconButton isSaved={isSaved} isRead={isRead} onClick={handleSaveClick} />
+      <EnvelopeText displayText={displayText} title={title} date={date} />
       {caption && <div>{caption}</div>}
       {date && <div>{date}</div>}
     </EnvelopeWrapper>

--- a/src/components/letterbox/Envelope/EnvelopeBody.tsx
+++ b/src/components/letterbox/Envelope/EnvelopeBody.tsx
@@ -1,12 +1,13 @@
-import { EnvelopeContainer, EnvelopeImage, FrameImage, WaxSeal } from "./EnvelopeStyles";
+import { EnvelopeContainer, EnvelopeImage, FrameImage, WaxSeal, InnerImage } from "./EnvelopeStyles";
 
 interface EnvelopeBodyProps {
   isRead: boolean;
   sealColor?: string;
   onClick: () => void;
+  image?: string; // 추가된 이미지
 }
 
-const EnvelopeBody = ({ isRead, sealColor, onClick }: EnvelopeBodyProps) => {
+const EnvelopeBody = ({ isRead, sealColor, onClick, image }: EnvelopeBodyProps) => {
   return (
     <EnvelopeContainer onClick={onClick} isRead={isRead}>
       <EnvelopeImage
@@ -14,14 +15,18 @@ const EnvelopeBody = ({ isRead, sealColor, onClick }: EnvelopeBodyProps) => {
         alt="편지 봉투"
         isRead={isRead}
       />
-      {/* 닫혀 있는 편지에만 실링왁스 표시 */}
+
       {!isRead && sealColor && (
         <WaxSeal
-          src={`/images/${sealColor}Wax.png`} 
+          src={`/images/${sealColor}Wax.png`}
           alt={`${sealColor} 실링왁스`}
         />
       )}
-      {isRead && <FrameImage src="/images/Frame.png" alt="프레임 이미지" />}
+      {isRead && (
+        <FrameImage>
+          {image && <InnerImage src={image} alt="사진 이미지" />}
+        </FrameImage>
+      )}
     </EnvelopeContainer>
   );
 };

--- a/src/components/letterbox/Envelope/EnvelopeStyles.ts
+++ b/src/components/letterbox/Envelope/EnvelopeStyles.ts
@@ -36,15 +36,32 @@ export const EnvelopeImage = styled.img<{ isRead: boolean }>`
   transition: all 0.3s ease-in-out;
 `;
 
-export const FrameImage = styled.img`
+export const FrameImage = styled.div`
   position: absolute;
   bottom: 0.3125rem;
   right: 0.3125rem;
   width: 7.8125rem;
   height: 6.875rem;
   z-index: 2;
+  background: url("/images/Frame.png") no-repeat center;
+  background-size: cover;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  
 `;
 
+export const InnerImage = styled.img`
+  position: absolute;
+  width: 6.25rem; 
+  height: 4.9rem; 
+  object-fit: cover; 
+  margin-bottom: 0.8rem;
+  margin-right: 0.2rem;
+
+  box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.1);
+`;
 
 export const WaxSeal = styled.img`
   position: absolute;

--- a/src/components/letterbox/LetterList.tsx
+++ b/src/components/letterbox/LetterList.tsx
@@ -11,6 +11,7 @@ interface LetterListProps {
     isRead: boolean;
     sealColor?: string;
     caption: string;
+    image: string;
   }>;
   onClick: (id: number) => void;
   onSave: (id: number) => void;
@@ -45,6 +46,7 @@ const LetterList = ({
           activeTab={activeTab}
           nickname={nickname}
           caption={letter.caption} 
+          image={letter.image}
         />
       ))}
     </EnvelopeFlex>


### PR DESCRIPTION

## #️⃣ Issue Number

#32

## 📝 요약(Summary)

- 우편 봉투가 열린 상태에서 프레임 내부에 이미지를 표시하도록 구현
- `EnvelopeBody` 및 관련 스타일링 수정
- 데이터에 따라 이미지가 적절히 렌더링되도록 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
